### PR TITLE
vimshell等から``を使うと余計な改行が入る問題を解決

### DIFF
--- a/plugin/vimproc.vim
+++ b/plugin/vimproc.vim
@@ -41,7 +41,7 @@ command! -nargs=+ -complete=shellcmd VimProcRead call s:read(<q-args>)
 function! s:bang(cmdline)"{{{
   " Expand % and #.
   let l:cmdline = join(map(vimproc#parser#split_args_through(
-        \ iconv(a:cmdline, &termencoding, &encoding)), 'expand(v:val)'))
+        \ iconv(a:cmdline, &termencoding, &encoding)), 'substitute(expand(v:val), "\n", " ", "g")'))
 
   " Open pipe.
   let l:subproc = vimproc#pgroup_open(l:cmdline)


### PR DESCRIPTION
`command`の結果の最後の最後にやってくる改行文字を消してみました。他のシェルと挙動を揃えています。
