### PR TITLE
fix compile error in NetBSD 5.0

### DIFF
--- a/autoload/proc.c
+++ b/autoload/proc.c
@@ -36,7 +36,7 @@
 #if defined __linux__ || defined __CYGWIN__
 # include <pty.h>
 # include <utmp.h>
-#elif defined __APPLE__ 
+#elif defined __APPLE__ || defined __NetBSD__
 # include <util.h>
 #else
 # include <termios.h>
@@ -58,6 +58,9 @@
 /* for waitpid() */
 #include <sys/types.h>
 #include <sys/wait.h>
+#if defined __NetBSD__
+#define WIFCONTINUED(x) (_WSTATUS(x) == _WSTOPPED && WSTOPSIG(x) == 0x13)
+#endif
 
 /* for socket */
 #include <sys/types.h>
@@ -853,7 +856,7 @@ vp_decode(char *args)
     p = str;
     bp = buf;
     for (i = 0; i < length; i++, p++) {
-        if (isdigit(*p))
+        if (isdigit((int)*p))
             num |= (*p & 15);
         else
             num |= (*p & 15) + 9;


### PR DESCRIPTION
fixes following error & warnings in NetBSD 5.0

<pre>
% make -f make_gcc.mak    
gcc -W -O2 -Wall -Wno-unused -std=gnu99 -pedantic -shared -fPIC -o autoload/proc.so autoload/proc.c  -lutil
autoload/proc.c:43:22: error: libutil.h: No such file or directory
autoload/proc.c: In function 'vp_pty_open':
autoload/proc.c:564: warning: implicit declaration of function 'openpty'
autoload/proc.c:571: warning: implicit declaration of function 'forkpty'
autoload/proc.c: In function 'vp_waitpid':
autoload/proc.c:750: warning: implicit declaration of function 'WIFCONTINUED'
autoload/proc.c: In function 'vp_decode':
autoload/proc.c:856: warning: array subscript has type 'char'
*** Error code 1

Stop.
make: stopped in /tmp/vimproc
</pre>
