### PR TITLE
add -arch for i386 vim (MacVim)

### DIFF
--- a/make_mac.mak
+++ b/make_mac.mak
@@ -2,7 +2,7 @@
 
 TARGET=autoload/vimproc_mac.so
 SRC=autoload/proc.c
-CFLAGS=-O2 -W -Wall -Wno-unused -bundle -fPIC
+CFLAGS=-O2 -W -Wall -Wno-unused -bundle -fPIC -arch x86_64 -arch i386
 LDFLAGS+=-lutil
 
 all: $(TARGET)


### PR DESCRIPTION
`-arch i386` for MacVim.

MacVim が i386 っぽいので universal binary を生成するようにして 64-bit でも 32-bit でも対応できるようにします
