### PR TITLE
Fixes for compiler warnings on MinGW64 Win7 64-bit

### DIFF
--- a/autoload/proc_w32.c
+++ b/autoload/proc_w32.c
@@ -99,7 +99,7 @@ EXPORT const char *vp_readdir(char *args);  /* [files] (dirname) */
 
 EXPORT const char * vp_delete_trash(char *args);  /* [filename] */
 
-static BOOL ExitRemoteProcess(HANDLE hProcess, UINT uExitCode);
+static BOOL ExitRemoteProcess(HANDLE hProcess, UINT_PTR uExitCode);
 
 /* --- */
 
@@ -507,12 +507,12 @@ vp_pipe_open(char *args)
 
     vp_stack_push_num(&_result, "%p", pi.hProcess);
     vp_stack_push_num(&_result, "%d", hstdin ?
-            0 : _open_osfhandle((long)hInputWrite, 0));
+            0 : _open_osfhandle((size_t)hInputWrite, 0));
     vp_stack_push_num(&_result, "%d", hstdout ?
-            0 : _open_osfhandle((long)hOutputRead, _O_RDONLY));
+            0 : _open_osfhandle((size_t)hOutputRead, _O_RDONLY));
     if (npipe == 3)
         vp_stack_push_num(&_result, "%d", hstderr ?
-                0 : _open_osfhandle((long)hErrorRead, _O_RDONLY));
+                0 : _open_osfhandle((size_t)hErrorRead, _O_RDONLY));
     return vp_stack_return(&_result);
 }
 
@@ -649,7 +649,7 @@ vp_kill(char *args)
 
 /* Improved kill function. */
 /* http://homepage3.nifty.com/k-takata/diary/2009-05.html */
-static BOOL ExitRemoteProcess(HANDLE hProcess, UINT uExitCode)
+static BOOL ExitRemoteProcess(HANDLE hProcess, UINT_PTR uExitCode)
 {
     LPTHREAD_START_ROUTINE pfnExitProcess =
         (LPTHREAD_START_ROUTINE) GetProcAddress(
@@ -957,7 +957,7 @@ vp_open(char *args)
     VP_RETURN_IF_FAIL(vp_stack_from_args(&stack, args));
     VP_RETURN_IF_FAIL(vp_stack_pop_str(&stack, &path));
 
-    if ((int)ShellExecute(NULL, "open", path, NULL, NULL, SW_SHOWNORMAL) < 32) {
+    if ((size_t)ShellExecute(NULL, "open", path, NULL, NULL, SW_SHOWNORMAL) < 32) {
         return vp_stack_return_error(&_result, "ShellExecute() error: %s",
                 lasterror());
     }


### PR DESCRIPTION
The pointer casting may or may not cause problems but I figured it's safer to change the types to be sure. Here are the compiler warnings that are fixed by my commits:

```
autoload/proc_w32.c:31:0: warning: "WINVER" redefined [enabled by default]
In file included from c:\mingw64\bin\../lib/gcc/x86_64-w64-mingw32/4.7.0/../../../../x86_64-w64-mingw32/include/stdio.h:9:0,
                 from autoload/proc_w32.c:22:
c:\mingw64\bin\../lib/gcc/x86_64-w64-mingw32/4.7.0/../../../../x86_64-w64-mingw32/include/_mingw.h:240:0: note: this is the location of the previous definition
autoload/proc_w32.c:32:0: warning: "_WIN32_WINNT" redefined [enabled by default]
In file included from c:\mingw64\bin\../lib/gcc/x86_64-w64-mingw32/4.7.0/../../../../x86_64-w64-mingw32/include/stdio.h:9:0,
                 from autoload/proc_w32.c:22:
c:\mingw64\bin\../lib/gcc/x86_64-w64-mingw32/4.7.0/../../../../x86_64-w64-mingw32/include/_mingw.h:244:0: note: this is the location of the previous definition
autoload/proc_w32.c: In function 'vp_pipe_open':
autoload/proc_w32.c:506:33: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
autoload/proc_w32.c:508:33: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
autoload/proc_w32.c:511:37: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
autoload/proc_w32.c: In function 'ExitRemoteProcess':
autoload/proc_w32.c:655:33: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
autoload/proc_w32.c: In function 'vp_open':
autoload/proc_w32.c:956:9: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
In file included from autoload/proc_w32.c:44:0:
autoload/proc_w32.c: At top level:
autoload/vimstack.c:42:19: warning: 'vp_stack_null' defined but not used [-Wunused-variable]
```
