### PR TITLE
Ignore tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ autoload/vimproc_*.so
 autoload/vimproc_*.dll
 autoload/vimproc_*.exp
 autoload/vimproc_*.lib
+doc/tags
 *.obj
 *.o
 *.swp


### PR DESCRIPTION
I'm using vimproc as a submodule, and it would be nice to ignore the generated tags file.
