### PR TITLE
vimproc#readdirのバグを修正しました.

### DIFF
--- a/autoload/vimproc.vim
+++ b/autoload/vimproc.vim
@@ -709,12 +709,12 @@ function! vimproc#readdir(dirname)"{{{
     return []
   endif
 
-  let dirname = iconv(dirname, &encoding,
+  let dirname = vimproc#util#iconv(dirname, &encoding,
         \ vimproc#util#termencoding())
 
   let files = s:libcall('vp_readdir', [dirname])
 
-  call map(files, 'iconv(v:val, vimproc#util#termencoding(), &encoding)')
+  call map(files, 'vimproc#util#iconv(v:val, vimproc#util#termencoding(), &encoding)')
 
   return files
 endfunction"}}}


### PR DESCRIPTION
vimprocとvimfilerを一緒に使うと, vimfiler上でディレクトリを移動した時に, エラーが出て, 移動先のディレクトリがきちんと表示されないという挙動でした.

以下のようなエラーです(:messagesで表示)
function 69_execute..69_cd_file_directory..vimfiler#mappings#cd..vimfiler#force_redraw_screen..vimfiler#get_directory_files..unite#get_vimfiler_candidates..33_get_c
andidates..33_recache_candidates..33_recache_candidates_loop..33_get_source_candidates..35..33..unite#util#glob..vimproc#readdir..100_libcall, line 16
vimproc: vp_readdir: ['opendir() error: No such file or directory']
[unite.vim] Error occured in vimfiler_gather_candidates!
[unite.vim] Source name is file
function vimfiler#mappings#cd..vimfiler#force_redraw_screen..vimfiler#get_directory_files..unite#get_vimfiler_candidates..33_get_candidates..33_recache_candidates..
33_recache_candidates_loop..33_get_source_candidates..35..33..unite#util#glob..vimproc#readdir..100_libcall, line 16
vimproc: vp_readdir: ['opendir() error: No such file or directory']
[unite.vim] Error occured in vimfiler_gather_candidates!
[unite.vim] Source name is file

vimproc#readdirの引数には正しそうな情報が入っていましたが, iconvを通過したあとにdirnameが空になっていました. 他の箇所ではiconvはvimproc#util#iconvとして使われているので, これらがどういう違いなのかは調べていませんが, 修正しました.

修正したvimproc#readdirでもう一度vimfiler上でのディレクトリ移動を行うと, 上記エラーメッセージは出なくなりました. 
