### PR TITLE
add android support

### DIFF
--- a/autoload/proc.c
+++ b/autoload/proc.c
@@ -34,12 +34,12 @@
 #endif
 
 /* for forkpty() / login_tty() */
-#if defined __linux__ || defined __CYGWIN__
+#if (defined __linux__ || defined __CYGWIN__) && !defined __ANDROID__
 # include <pty.h>
 # include <utmp.h>
 #elif defined __APPLE__ || defined __NetBSD__
 # include <util.h>
-#elif defined __sun
+#elif defined __sun || defined __ANDROID__
 # include "ptytty.c"
 #else
 # include <termios.h>
@@ -63,6 +63,8 @@
 #include <sys/wait.h>
 #if defined __NetBSD__
 #define WIFCONTINUED(x) (_WSTATUS(x) == _WSTOPPED && WSTOPSIG(x) == 0x13)
+#elif defined __ANDROID__
+#define WIFCONTINUED(x) (WIFSTOPPED(x) && WSTOPSIG(x) == 0x13)
 #endif
 
 /* for socket */

--- a/autoload/ptytty.c
+++ b/autoload/ptytty.c
@@ -7,11 +7,18 @@
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef __ANDROID__
 #include <stropts.h>
+#endif
 #include <unistd.h>
 
 #include <signal.h>
 #include <termios.h>
+
+#ifdef __ANDROID__
+#define TTYNAME_MAX PATH_MAX
+#endif
+
 
 static int
 _sunos_get_pty(int *master, char **path)
@@ -38,12 +45,14 @@ _sunos_get_tty(int *slave, char *path,
     if (ctty && ioctl(*slave, TIOCSCTTY, NULL) == -1)
         return -1;
 #endif
+#ifndef __ANDROID__
     if (ioctl(*slave, I_PUSH, "ptem") == -1)
         return -1;
     if (ioctl(*slave, I_PUSH, "ldterm") == -1)
         return -1;
     if (ioctl(*slave, I_PUSH, "ttcompat") == -1)
         return -1;
+#endif
 
     if (termp != NULL)
         tcsetattr(*slave, TCSAFLUSH, termp);

--- a/make_android.mak
+++ b/make_android.mak
@@ -1,0 +1,21 @@
+# You must set environment variables to suit your environment, in this Makefile or your shell.
+# For example, using Android NDK on Mac OSX:
+#   NDK_TOP=/path/to/your/ndk/android-ndk-r8d
+#   SYSROOT=$(NDK_TOP)/platforms/android-8/arch-arm
+#   CFLAGS=-march=armv5te -msoft-float
+#   CC=$(NDK_TOP)/toolchains/arm-linux-androideabi-4.4.3/prebuilt/darwin-x86/bin/arm-linux-androideabi-gcc -mandroid --sysroot=$(SYSROOT)
+
+CFLAGS+=-W -Wall -Wno-unused -std=c99 -O2 -fPIC -pedantic
+LDFLAGS+=-shared
+
+TARGET=autoload/vimproc_unix.so
+SRC=autoload/proc.c
+INC=autoload/vimstack.c autoload/ptytty.c
+
+all: $(TARGET)
+
+$(TARGET): $(SRC) $(INC)
+	$(CC) $(CFLAGS) -o $(TARGET) $(SRC) $(LDFLAGS)
+
+clean:
+	rm -f $(TARGET)


### PR DESCRIPTION
The implementation for android uses ptytty.c like sunos because Android
NDK does not have libutil. But in ptytty.c, 'STREAMS modules pushing' is
not supported in Android and seems to be not needed, therefore I disable
it for Android.
And in proc.c, Android does not support WIFCONTINUED, it uses WIFSTOPPED
and WSTOPSIG instead.

NOTICE:
Some environment variables are needed for make. This notice is also
written in make_android.mak with an example.
