### PR TITLE
vimproc#read_line の結果がおかしい

### DIFF
--- a/autoload/vimproc.vim
+++ b/autoload/vimproc.vim
@@ -906,14 +906,9 @@ function! s:read_lines(...) dict "{{{
 
   let lines = split(res, '\r\?\n', 1)
 
+  let self.buffer = ''
   if self.eof
-    let self.buffer = ''
     return lines
-  elseif res[-1] == '\n'
-    let self.buffer = empty(lines)? '' : lines[-1]
-    let lines = lines[ : -2]
-  else
-    let self.buffer = ''
   endif
 
   let self.eof = (self.buffer != '') ? 0 : self.__eof


### PR DESCRIPTION
``` vim
let tmpfile = tempname()
let lines = []
for i in range(100)
    let lines += [printf("%s", i)]
endfor
call writefile(lines, tmpfile)
let f = vimproc#fopen(tmpfile, 'r')
for i in range(60)
    echo f.read_line()
endfor
```

これを実行すると、
51 以降の番号が結合された結果が復帰されます。

関連：https://github.com/vim-jp/vital.vim/issues/92
