### PR TITLE
Use clang to build vimproc in Mac

### DIFF
--- a/make_mac.mak
+++ b/make_mac.mak
@@ -1,7 +1,11 @@
 # for Mac.
 
-# clang or llvm-gcc
+ifeq ($(shell which clang),)
 LLVMCC=llvm-gcc
+else
+LLVMCC=clang
+endif
+
 
 ifneq ($(shell which $(LLVMCC)),)
 CC=$(LLVMCC)


### PR DESCRIPTION
I changed to use clang to build vimproc in Mac because llvm-gcc seems to be removed in Marvericks.

I ran tests and confirmed that all tests are passed except for `test-fopen`, which is not passed even if llvm-gcc is used.
Additionally, I use some plugins which uses vimproc with vimproc built with clang.  It seems to work well.
