### PR TITLE
Fixed type of signal values

### DIFF
--- a/autoload/vimproc.vim
+++ b/autoload/vimproc.vim
@@ -98,7 +98,7 @@ function! s:define_signals()
   let xs = s:libcall('vp_get_signals', [])
   for x in xs
     let [name, val] = split(x, ':')
-    let g:vimproc#{name} = val
+    let g:vimproc#{name} = str2nr(val)
     call add(s:signames, name)
   endfor
 endfunction


### PR DESCRIPTION
すみません、#97 の変更で `g:vimproc#SIG*` の値が String になっていたので Number に修正しました。
