### PR TITLE
Fix typos of open() flag

### DIFF
--- a/autoload/proc.c
+++ b/autoload/proc.c
@@ -241,7 +241,7 @@ vp_file_open(char *args)
     if (strstr(flags, "O_RANDOM"))      f |= O_RANDOM;
 #endif
 #ifdef O_SEQUENTIAL
-    if (strstr(flags, "O_SEQENTIAL"))   f |= O_SEQUENTIAL;
+    if (strstr(flags, "O_SEQUENTIAL"))  f |= O_SEQUENTIAL;
 #endif
 #ifdef O_BINARY
     if (strstr(flags, "O_BINARY"))      f |= O_BINARY;

--- a/autoload/proc_w32.c
+++ b/autoload/proc_w32.c
@@ -232,7 +232,7 @@ vp_file_open(char *args)
     if (strstr(flags, "O_RANDOM"))      f |= O_RANDOM;
 #endif
 #ifdef O_SEQUENTIAL
-    if (strstr(flags, "O_SEQENTIAL"))   f |= O_SEQUENTIAL;
+    if (strstr(flags, "O_SEQUENTIAL"))  f |= O_SEQUENTIAL;
 #endif
 #ifdef O_BINARY
     if (strstr(flags, "O_BINARY"))      f |= O_BINARY;


### PR DESCRIPTION
O_SEQENTIAL -> O_SEQUENTIAL

フラグ名の綴りが間違っています。もっとも、これを直してしまうと、これを使っているものがあった場合に影響が出てしまうので、 O_SEQUENTIAL を追加するだけの方がよいのかもしれませんが。
