### PR TITLE
readdir() may crash when FindFirstFileEx() fails

### DIFF
--- a/autoload/proc_w32.c
+++ b/autoload/proc_w32.c
@@ -970,7 +970,7 @@ vp_readdir(char *args)
     if (h == INVALID_HANDLE_VALUE) {
         return vp_stack_return_error(&_result,
                 "FindFirstFileEx() error: %s",
-                GetLastError());
+                lasterror());
     }
 
     do {


### PR DESCRIPTION
lasterror() を使うべきところを、GetLastError() を使っているので、"%s" で文字列を表示しようとして変なアドレスをアクセスする可能性があると思われます。
