### PR TITLE
More explicitly specified gcc exec

### DIFF
--- a/make_mingw32.mak
+++ b/make_mingw32.mak
@@ -8,7 +8,7 @@ LDFLAGS+=-lwsock32
 all: $(TARGET)
 
 $(TARGET): $(SRC) autoload/vimstack.c
-	gcc $(CFLAGS) -o $(TARGET) $(SRC) $(LDFLAGS)
+	mingw32-gcc $(CFLAGS) -o $(TARGET) $(SRC) $(LDFLAGS)
 
 clean:
 	rm -f $(TARGET)


### PR DESCRIPTION
If used on a system with Cygwin installed, the old makefile using just `gcc` would fail. More explicitly specifying the mingw compiler ensures that this will work properly.
