### PR TITLE
avoid using gcc or mingw32-gcc directly, use CC instead

### DIFF
--- a/make_mingw32.mak
+++ b/make_mingw32.mak
@@ -2,13 +2,14 @@
 
 TARGET=autoload/vimproc_win32.dll
 SRC=autoload/proc_w32.c
+CC=mingw32-gcc
 CFLAGS=-O2 -Wall -shared -m32
 LDFLAGS+=-lwsock32
 
 all: $(TARGET)
 
 $(TARGET): $(SRC) autoload/vimstack.c
-	mingw32-gcc $(CFLAGS) -o $(TARGET) $(SRC) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $(TARGET) $(SRC) $(LDFLAGS)
 
 clean:
 	rm -f $(TARGET)

--- a/make_mingw64.mak
+++ b/make_mingw64.mak
@@ -2,13 +2,14 @@
 
 TARGET=autoload/vimproc_win64.dll
 SRC=autoload/proc_w32.c
+CC=mingw32-gcc
 CFLAGS=-O2 -Wall -shared -m64
 LDFLAGS+=-lwsock32
 
 all: $(TARGET)
 
 $(TARGET): $(SRC) autoload/vimstack.c
-	gcc $(CFLAGS) -o $(TARGET) $(SRC) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $(TARGET) $(SRC) $(LDFLAGS)
 
 clean:
 	rm -f $(TARGET)


### PR DESCRIPTION
When MinGW(-w64) package is installed on Cygwin, the executable name is
i686-pc-mingw32-gcc, i686-w64-mingw32-gcc or x86_64-w64-mingw32-gcc.
It's better to define CC variable and use it.

Related: #119
