### PR TITLE
Fix MinGW64 build issue (fix #123, #122)

### DIFF
--- a/make_mingw64.mak
+++ b/make_mingw64.mak
@@ -2,7 +2,7 @@
 
 TARGET=autoload/vimproc_win64.dll
 SRC=autoload/proc_w32.c
-CC=mingw32-gcc
+CC=x86_64-w64-mingw32-gcc
 CFLAGS=-O2 -Wall -shared -m64
 LDFLAGS+=-lwsock32
 


### PR DESCRIPTION
MinGW64 doesn't have mingw32-gcc. $(CC) should be x86_64-w64-mingw32-gcc.
