### PR TITLE
Fix windows internal commands

### DIFF
--- a/autoload/vimproc.vim
+++ b/autoload/vimproc.vim
@@ -1034,7 +1034,7 @@ function! s:convert_args(args) "{{{
           \ 'copy', 'date', 'del', 'dir', 'echo', 'erase', 'ftype',
           \ 'md', 'mkdir', 'move', 'path', 'rd', 'ren', 'rename',
           \ 'rmdir', 'start', 'time', 'type', 'ver', 'vol']
-    let index = index(internal_commands, a:args[0])
+    let index = index(internal_commands, a:args[0], 0, 1)
     if index >= 0
       " Use cmd.exe
       return ['cmd', '/c', internal_commands[index]] + a:args[1:]


### PR DESCRIPTION
- Windowsの内部コマンドのリストを更新
- 内部コマンドは ignore case で比較すべき
