### PR TITLE
fix handle leak in vp_pipe_open()

### DIFF
--- a/autoload/proc_w32.c
+++ b/autoload/proc_w32.c
@@ -470,6 +470,7 @@ vp_pipe_open(char *args)
     if (hstdin) {
         /* Get handle. */
         VP_DUP_HANDLE((HANDLE)_get_osfhandle(hstdin), &hInputRead, TRUE);
+        _close(hstdin);
     } else {
         HANDLE hInputWriteTmp;
 
@@ -485,6 +486,7 @@ vp_pipe_open(char *args)
     if (hstdout) {
         /* Get handle. */
         VP_DUP_HANDLE((HANDLE)_get_osfhandle(hstdout), &hOutputWrite, TRUE);
+        _close(hstdout);
     } else {
         HANDLE hOutputReadTmp;
 
@@ -503,6 +505,7 @@ vp_pipe_open(char *args)
         if (hstderr) {
             /* Get handle. */
             VP_DUP_HANDLE((HANDLE)_get_osfhandle(hstderr), &hErrorWrite, TRUE);
+            _close(hstderr);
         } else {
             HANDLE hErrorReadTmp;
 
@@ -563,6 +566,12 @@ error:
             if (handles[i] != INVALID_HANDLE_VALUE)
                 CloseHandle(handles[i]);
         }
+        if (hstdin)
+            _close(hstdin);
+        if (hstdout)
+            _close(hstdout);
+        if (hstderr)
+            _close(hstderr);
     }
     return vp_stack_return_error(&_result, errfmt, errmsg);
 #undef VP_DUP_HANDLE


### PR DESCRIPTION
Also fix the wrong usage of CRT functions.  A handle returned by
_get_osfhandle() should not be passed to CloseHandle(), because it will
be closed automatically when closing the fd using _close().
