### PR TITLE
Improved measurement of s:system elapsed time

### DIFF
--- a/autoload/vimproc.vim
+++ b/autoload/vimproc.vim
@@ -244,8 +244,9 @@ function! s:system(cmdline, is_passwd, input, timeout, is_pty) "{{{
   while !subproc.stdout.eof || !subproc.stderr.eof
     if timeout > 0 "{{{
       " Check timeout.
-      let end = split(reltimestr(reltime(start)))[0] * 1000
-      if end > timeout && !subproc.stdout.eof
+      let tick = reltimestr(reltime(start))
+      let elapse = str2nr(tick[:-8] . tick[-6:-4], 10)
+      if elapse > timeout && !subproc.stdout.eof
         " Kill process.
         try
           call subproc.kill(g:vimproc#SIGTERM)


### PR DESCRIPTION
`end` が `n * 1000` (n &isin; N &cup; {0}) の値しか取らないため、タイムアウト判定が秒精度になっています。

``` vim
call vimproc#system('sleep 3', '', 10)
" 10msec経過ではタイムアウトせず、1sec経過でタイムアウト
```

仕様通りミリ秒精度でタイムアウトを判定できるように変更しました。
