### PR TITLE
Modified s:last_status value

### DIFF
--- a/autoload/vimproc.vim
+++ b/autoload/vimproc.vim
@@ -1501,9 +1501,10 @@ function! s:waitpid(pid)
       call s:libcall('vp_close_handle', [a:pid])
     endif
 
-    let s:last_status = status
+    let s:last_status = str2nr(status)
   catch
     let [cond, status] = ['error', '0']
+    let s:last_status = -1
   endtry
 
   return [cond, str2nr(status)]


### PR DESCRIPTION
`s:waitpid()` で例外送出した場合は `s:last_status` を `-1` にしたい。
コマンド終了ステータスは 0~255 なので区別できます。
