### PR TITLE
Improve read/write performance

### DIFF
--- a/autoload/proc.c
+++ b/autoload/proc.c
@@ -90,21 +90,21 @@ const char *vp_dlversion(char *args);   /* [version] () */
 
 const char *vp_file_open(char *args);   /* [fd] (path, flags, mode) */
 const char *vp_file_close(char *args);  /* [] (fd) */
-const char *vp_file_read(char *args);   /* [hd, eof] (fd, nr, timeout) */
-const char *vp_file_write(char *args);  /* [nleft] (fd, hd, timeout) */
+const char *vp_file_read(char *args);   /* [hd, eof] (fd, cnt, timeout) */
+const char *vp_file_write(char *args);  /* [nleft] (fd, timeout, hd) */
 
 const char *vp_pipe_open(char *args);   /* [pid, [fd] * npipe]
                                            (npipe, hstdin, hstdout, hstderr, argc, [argv]) */
 const char *vp_pipe_close(char *args);  /* [] (fd) */
-const char *vp_pipe_read(char *args);   /* [hd, eof] (fd, nr, timeout) */
-const char *vp_pipe_write(char *args);  /* [nleft] (fd, hd, timeout) */
+const char *vp_pipe_read(char *args);   /* [hd, eof] (fd, cnt, timeout) */
+const char *vp_pipe_write(char *args);  /* [nleft] (fd, timeout, hd) */
 
 const char *vp_pty_open(char *args);
 /* [pid, stdin, stdout, stderr]
    (npipe, width, height,hstdin, hstdout, hstderr, argc, [argv]) */
 const char *vp_pty_close(char *args);   /* [] (fd) */
-const char *vp_pty_read(char *args);    /* [hd, eof] (fd, nr, timeout) */
-const char *vp_pty_write(char *args);   /* [nleft] (fd, hd, timeout) */
+const char *vp_pty_read(char *args);    /* [hd, eof] (fd, cnt, timeout) */
+const char *vp_pty_write(char *args);   /* [nleft] (fd, timeout, hd) */
 const char *vp_pty_get_winsize(char *args); /* [width, height] (fd) */
 const char *vp_pty_set_winsize(char *args); /* [] (fd, width, height) */
 
@@ -113,7 +113,7 @@ const char *vp_waitpid(char *args);     /* [cond, status] (pid) */
 
 const char *vp_socket_open(char *args); /* [socket] (host, port) */
 const char *vp_socket_close(char *args);/* [] (socket) */
-const char *vp_socket_read(char *args); /* [hd, eof] (socket, nr, timeout) */
+const char *vp_socket_read(char *args); /* [hd, eof] (socket, cnt, timeout) */
 const char *vp_socket_write(char *args);/* [nleft] (socket, hd, timeout) */
 
 const char *vp_host_exists(char *args); /* [int] (host) */
@@ -123,7 +123,8 @@ const char *vp_decode(char *args);      /* [decoded_str] (encode_str) */
 const char *vp_get_signals(char *args); /* [signals] () */
 /* --- */
 
-#define VP_READ_BUFSIZE 2048
+#define VP_BUFSIZE      (65536)
+#define VP_READ_BUFSIZE (VP_BUFSIZE - 4)
 
 static vp_stack_t _result = VP_STACK_NULL;
 
@@ -149,6 +150,7 @@ vp_dlopen(char *args)
 
     VP_RETURN_IF_FAIL(vp_stack_from_args(&stack, args));
     VP_RETURN_IF_FAIL(vp_stack_pop_str(&stack, &path));
+    VP_RETURN_IF_FAIL(vp_stack_reserve(&_result, VP_BUFSIZE));
 
     handle = dlopen(path, RTLD_LAZY);
     if (handle == NULL)
@@ -284,55 +286,58 @@ vp_file_read(char *args)
 {
     vp_stack_t stack;
     int fd;
-    int nr;
+    int cnt;
     int timeout;
     int n;
-    char buf[VP_READ_BUFSIZE];
+    char *buf;
+    char *eof;
     struct pollfd pfd = {0, POLLIN, 0};
 
     VP_RETURN_IF_FAIL(vp_stack_from_args(&stack, args));
     VP_RETURN_IF_FAIL(vp_stack_pop_num(&stack, "%d", &fd));
-    VP_RETURN_IF_FAIL(vp_stack_pop_num(&stack, "%d", &nr));
+    VP_RETURN_IF_FAIL(vp_stack_pop_num(&stack, "%d", &cnt));
     VP_RETURN_IF_FAIL(vp_stack_pop_num(&stack, "%d", &timeout));
 
+    if (cnt < 0 || VP_READ_BUFSIZE < cnt) {
+        cnt = VP_READ_BUFSIZE;
+    }
+
+    /* initialize buffer */
+    buf = _result.top = _result.buf;
+    *(buf++) = VP_EOV;
+    *(eof = buf++) = '0';
+
     pfd.fd = fd;
-    vp_stack_push_str(&_result, ""); /* initialize */
-    while (nr != 0) {
+    while (cnt > 0) {
         n = poll(&pfd, 1, timeout);
         if (n == -1) {
             /* eof or error */
-            vp_stack_push_num(&_result, "%d", 1);
-            return vp_stack_return(&_result);
+            *eof = '1';
+            break;
         } else if (n == 0) {
             /* timeout */
             break;
         }
         if (pfd.revents & POLLIN) {
-            if (nr > 0)
-                n = read(fd, buf,
-                        (VP_READ_BUFSIZE < nr) ? VP_READ_BUFSIZE : nr);
-            else
-                n = read(fd, buf, VP_READ_BUFSIZE);
+            n = read(fd, buf, cnt);
             if (n == -1) {
                 return vp_stack_return_error(&_result, "read() error: %s",
                         strerror(errno));
             } else if (n == 0) {
                 /* eof */
-                vp_stack_push_num(&_result, "%d", 1);
-                return vp_stack_return(&_result);
+                *eof = '1';
+                break;
             }
             /* decrease stack top for concatenate. */
-            _result.top--;
-            vp_stack_push_bin(&_result, buf, n);
-            if (nr > 0)
-                nr -= n;
+            cnt -= n;
+            buf += n;
             /* try read more bytes without waiting */
             timeout = 0;
             continue;
         } else if (pfd.revents & (POLLERR | POLLHUP)) {
             /* eof or error */
-            vp_stack_push_num(&_result, "%d", 1);
-            return vp_stack_return(&_result);
+            *eof = '1';
+            break;
         } else if (pfd.revents & POLLNVAL) {
             return vp_stack_return_error(&_result, "poll() POLLNVAL: %d",
                     pfd.revents);
@@ -341,7 +346,7 @@ vp_file_read(char *args)
         return vp_stack_return_error(&_result, "poll() unknown status: %d",
                 pfd.revents);
     }
-    vp_stack_push_num(&_result, "%d", 0);
+    _result.top = buf;
     return vp_stack_return(&_result);
 }
 
@@ -359,8 +364,11 @@ vp_file_write(char *args)
 
     VP_RETURN_IF_FAIL(vp_stack_from_args(&stack, args));
     VP_RETURN_IF_FAIL(vp_stack_pop_num(&stack, "%d", &fd));
-    VP_RETURN_IF_FAIL(vp_stack_pop_bin(&stack, &buf, &size));
     VP_RETURN_IF_FAIL(vp_stack_pop_num(&stack, "%d", &timeout));
+
+    buf = stack.buf;
+    size = (stack.top - 1) - stack.buf;
+    buf[size] = 0;
 
     pfd.fd = fd;
     nleft = 0;

--- a/autoload/vimproc.vim
+++ b/autoload/vimproc.vim
@@ -865,38 +865,30 @@ function! s:read(...) dict "{{{
     return ''
   endif
 
-  let number = get(a:000, 0, -1)
+  let maxsize = get(a:000, 0, -1)
   let timeout = get(a:000, 1, s:read_timeout)
-  let is_oneline = get(a:000, 2, 0)
-
+  let buf = []
   let eof = 0
-  let max = 100
-  let hds = []
-  let rest_num = number
-  for cnt in range(1, max)
-    let timeout1 = timeout / (max + 1 - cnt)
-    if timeout > 0 && timeout1 == 0
-      let timeout1 = 1
-    endif
-    let [hd_r, eof] = self.f_read(number, timeout1)
-    let rest_num -= strlen(hd_r) / 2
-    let timeout -= timeout1
-    let hds += [hd_r]
 
-    if eof || (is_oneline && stridx(hd_r, '0A') % 2 == 0)
-          \ || (number >= 0 && rest_num <= 0) || (timeout <= 0)
-      break
+  while maxsize != 0 && !eof
+    let [out, eof] = self.f_read(maxsize, 
+          \ (timeout < s:read_timeout ? timeout : s:read_timeout))
+    if out ==# ''
+      if timeout <= s:read_timeout
+        break
+      endif
+      let timeout -= s:read_timeout
+    else
+      let buf += [out]
+      let maxsize -= len(out)
+      let timeout = 0
     endif
-  endfor
+  endwhile
 
   let self.eof = eof
   let self.__eof = eof
 
-  let hd = join(hds, '')
-  return hd == '' ? '' :
-        \ vimproc#util#has_lua() ?
-        \   s:hd2str_lua([hd]) : s:hd2str([hd])
-  " return s:hd2str([hd])
+  return join(buf, '')
 endfunction"}}}
 function! s:read_lines(...) dict "{{{
   let res = self.buffer
@@ -932,8 +924,7 @@ endfunction"}}}
 
 function! s:write(str, ...) dict "{{{
   let timeout = get(a:000, 0, s:write_timeout)
-  let hd = s:str2hd(a:str)
-  return self.f_write(hd, timeout)
+  return self.f_write(a:str, timeout)
 endfunction"}}}
 
 function! s:fdopen(fd, f_close, f_read, f_write) "{{{
@@ -1191,6 +1182,46 @@ function! s:libcall(func, args) "{{{
   return result[:-2]
 endfunction"}}}
 
+function! s:libcall_raw_read(func, args) "{{{
+  " End Of Value
+  let EOV = "\xFF"
+  let args = empty(a:args) ? '' : (join(reverse(copy(a:args)), EOV) . EOV)
+  let result = libcall(g:vimproc#dll_path, a:func, args)
+  " SUCCESS:: EOV | EOF[0|1] | Bin
+  " ERROR  :: ErrStr
+  if result[0] !=# EOV
+    let s:lasterr = [result]
+    let msg = vimproc#util#iconv(string(result),
+          \ vimproc#util#systemencoding(), &encoding)
+
+    throw printf('vimproc: %s: %s', a:func, msg)
+  endif
+  return [result[2:], result[1]]
+endfunction"}}}
+
+function! s:libcall_raw_write(func, args) "{{{
+  " End Of Value
+  let EOV = "\xFF"
+  " Convert::
+  " [Fd, Bin, Timeout] => Bin | EOV | Timeout | EOV | Fd | EOV
+  let args = join((a:args[1:] + a:args[:0]), EOV) . EOV
+  let stack_buf = libcall(g:vimproc#dll_path, a:func, args)
+  let result = s:split(stack_buf, EOV)
+  if get(result, -1, 'error') != ''
+    if stack_buf[len(stack_buf) - 1] ==# EOV
+      " Note: If &encoding equals "cp932" and output ends multibyte first byte,
+      "       will fail split.
+      return result
+    endif
+    let s:lasterr = result
+    let msg = vimproc#util#iconv(string(result),
+          \ vimproc#util#systemencoding(), &encoding)
+
+    throw printf('vimproc: %s: %s', a:func, msg)
+  endif
+  return result[:-2]
+endfunction"}}}
+
 function! s:SID_PREFIX()
   if !exists('s:sid_prefix')
     let s:sid_prefix = matchstr(expand('<sfile>'),
@@ -1234,12 +1265,12 @@ function! s:vp_file_close() dict
 endfunction
 
 function! s:vp_file_read(number, timeout) dict
-  let [hd, eof] = s:libcall('vp_file_read', [self.fd, a:number, a:timeout])
+  let [hd, eof] = s:libcall_raw_read('vp_file_read', [self.fd, a:number, a:timeout])
   return [hd, eof]
 endfunction
 
 function! s:vp_file_write(hd, timeout) dict
-  let [nleft] = s:libcall('vp_file_write', [self.fd, a:hd, a:timeout])
+  let [nleft] = s:libcall_raw_write('vp_file_write', [self.fd, a:hd, a:timeout])
   return nleft
 endfunction
 
@@ -1297,7 +1328,7 @@ function! s:vp_pipe_read(number, timeout) dict
     return ['', 1]
   endif
 
-  let [hd, eof] = s:libcall('vp_pipe_read', [self.fd, a:number, a:timeout])
+  let [hd, eof] = s:libcall_raw_read('vp_pipe_read', [self.fd, a:number, a:timeout])
   return [hd, eof]
 endfunction
 
@@ -1306,7 +1337,7 @@ function! s:vp_pipe_write(hd, timeout) dict
     return 0
   endif
 
-  let [nleft] = s:libcall('vp_pipe_write', [self.fd, a:hd, a:timeout])
+  let [nleft] = s:libcall_raw_write('vp_pipe_write', [self.fd, a:hd, a:timeout])
   return nleft
 endfunction
 
@@ -1416,12 +1447,12 @@ function! s:vp_pty_close() dict
 endfunction
 
 function! s:vp_pty_read(number, timeout) dict
-  let [hd, eof] = s:libcall('vp_pty_read', [self.fd, a:number, a:timeout])
+  let [hd, eof] = s:libcall_raw_read('vp_pty_read', [self.fd, a:number, a:timeout])
   return [hd, eof]
 endfunction
 
 function! s:vp_pty_write(hd, timeout) dict
-  let [nleft] = s:libcall('vp_pty_write', [self.fd, a:hd, a:timeout])
+  let [nleft] = s:libcall_raw_write('vp_pty_write', [self.fd, a:hd, a:timeout])
   return nleft
 endfunction
 
@@ -1578,13 +1609,13 @@ function! s:vp_socket_close() dict
 endfunction
 
 function! s:vp_socket_read(number, timeout) dict
-  let [hd, eof] = s:libcall('vp_socket_read',
+  let [hd, eof] = s:libcall_raw_read('vp_socket_read',
         \ [self.fd, a:number, a:timeout])
   return [hd, eof]
 endfunction
 
 function! s:vp_socket_write(hd, timeout) dict
-  let [nleft] = s:libcall('vp_socket_write',
+  let [nleft] = s:libcall_raw_write('vp_socket_write',
         \ [self.fd, a:hd, a:timeout])
   return nleft
 endfunction

--- a/autoload/vimstack.c
+++ b/autoload/vimstack.c
@@ -176,17 +176,17 @@ vp_stack_pop_num(vp_stack_t *stack, const char *fmt, void *ptr)
 {
     char fmtbuf[VP_NUMFMT_BUFSIZE];
     int n;
-    char *top;
+    char *top, *bot;
 
     if (stack->buf == stack->top)
         return "vp_stack_pop_num: stack over flow";
 
     top = stack->top - 1;
-    while (top != stack->buf && top[-1] != VP_EOV)
+    bot = stack->buf;
+    while (top != bot && top[-1] != VP_EOV)
         --top;
 
-    strcpy(fmtbuf, fmt);
-    strcat(fmtbuf, "%n");
+    snprintf(fmtbuf, VP_NUMFMT_BUFSIZE, "%s%%n", fmt);
 
     if (sscanf(top, fmtbuf, ptr, &n) != 1 || top[n] != VP_EOV)
         return "vp_stack_pop_num: sscanf error";
@@ -199,13 +199,14 @@ vp_stack_pop_num(vp_stack_t *stack, const char *fmt, void *ptr)
 static const char *
 vp_stack_pop_str(vp_stack_t *stack, char **str)
 {
-    char *top;
+    char *top, *bot;
 
     if (stack->buf == stack->top)
         return "vp_stack_pop_str: stack over flow";
 
     top = stack->top - 1;
-    while (top != stack->buf && top[-1] != VP_EOV)
+    bot = stack->buf;
+    while (top != bot && top[-1] != VP_EOV)
         --top;
 
     *str = top;


### PR DESCRIPTION
#### read/write データをそのまま扱う (`hd2str()`, `str2hd()` を通さない)

データを Vim script に上げた時点で '\0' 以降は欠落するので、
hexdump せずに直接扱うようにしました。
そのために、read/write については専用の `s:libcall_raw_read()`, `s:libcall_raw_write()` を用意し、
C との引数／戻り値の形式を変更しました。
#### C 戻り値のバッファサイズ変更

C の `_result` に充てるバッファサイズを 64kB に固定しました。
C での `read()` は 64kB を上限として Vim script 側に戻ります。 
