### PR TITLE
Fix vp_kill

### DIFF
--- a/autoload/proc.c
+++ b/autoload/proc.c
@@ -775,6 +775,14 @@ vp_pty_set_winsize(char *args)
     return NULL;
 }
 
+static pid_t
+get_pid()
+{
+    static pid_t pid = -1;
+
+    return (pid != -1) ? pid : (pid = getpid());
+}
+
 const char *
 vp_kill(char *args)
 {
@@ -795,7 +803,7 @@ vp_kill(char *args)
     if (sig != 0) {
         /* Kill by the process group. */
         pgid = getpgid(pid);
-        if (pgid > 0) {
+        if (pgid > 1 && pgid != get_pid()) {
             kill(-pgid, sig);
         }
     }


### PR DESCRIPTION
https://gist.github.com/osyo-manga/bd7889e669dfe1f1bbf8
この `call Test()` を実行すると、`fork` 〜 `setpgid` が完了する前に
子プロセスグループへの `kill` が呼ばれることがあり、Vim ごと落ちます。 
(Ubuntu 14.04, CentOS 7 で確認)

子プロセスの pgid が親 (VIm) の pid と同じ場合にはプロセスグループの kill を行なわないようにしました。
