### PR TITLE
Fix vp_kill

### DIFF
--- a/autoload/proc.c
+++ b/autoload/proc.c
@@ -775,14 +775,6 @@ vp_pty_set_winsize(char *args)
     return NULL;
 }
 
-static pid_t
-get_pid()
-{
-    static pid_t pid = -1;
-
-    return (pid != -1) ? pid : (pid = getpid());
-}
-
 const char *
 vp_kill(char *args)
 {
@@ -803,7 +795,7 @@ vp_kill(char *args)
     if (sig != 0) {
         /* Kill by the process group. */
         pgid = getpgid(pid);
-        if (pgid > 1 && pgid != get_pid()) {
+        if (pid == pgid) {
             kill(-pgid, sig);
         }
     }


### PR DESCRIPTION
#169

kill 対象がプロセスグループリーダーの場合のみ pgid を kill するように変更しました。
