### PR TITLE
Resolve shortcuts on Windows. Fixes #173.

### DIFF
--- a/make_mingw32.mak
+++ b/make_mingw32.mak
@@ -4,7 +4,7 @@ TARGET=autoload/vimproc_win32.dll
 SRC=autoload/proc_w32.c
 CC=gcc
 CFLAGS=-O2 -Wall -shared -m32
-LDFLAGS+=-lwsock32
+LDFLAGS+=-lwsock32 -luser32 -lole32
 
 all: $(TARGET)
 

--- a/make_mingw64.mak
+++ b/make_mingw64.mak
@@ -4,7 +4,7 @@ TARGET=autoload/vimproc_win64.dll
 SRC=autoload/proc_w32.c
 CC=x86_64-w64-mingw32-gcc
 CFLAGS=-O2 -Wall -shared -m64
-LDFLAGS+=-lwsock32
+LDFLAGS+=-lwsock32 -luser32 -lole32
 
 all: $(TARGET)
 

--- a/make_msvc.mak
+++ b/make_msvc.mak
@@ -63,7 +63,7 @@ clean:
 
 $(SRCDIR)\$(VIMPROC).dll: $(OBJS)
 	$(link) /NOLOGO $(ldebug) $(dlllflags) $(conlibsdll) $(LFLAGS) \
-		/OUT:$@ $(OBJS) shell32.lib
+		/OUT:$@ $(OBJS) shell32.lib user32.lib ole32.lib
 	IF EXIST $@.manifest \
 		mt -nologo -manifest $@.manifest -outputresource:$@;2
 


### PR DESCRIPTION
This PR tries to resolve shortcuts on Windows if we first failed to execute the requested file.

This way we can avoid any overhead that might come from checking if the file is a shortcut. I'm not sure how performance critical do you see this, should I just check if it's a shortcut and resolve it before even trying to execute it?

Sadly I haven't tested the MinGW version, only the MSVC. Does Travis check at least its compilation for me?

Fixes #173.
