### PR TITLE
Add VimProcInstall command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,18 @@
 ifeq ($(OS),Windows_NT)
-    # Fail if this is a windows platform
-    $(error Windows is not supported by this makefile, please use appropriate .mak file)
+    # Need to figure out if Cygwin/Mingw is installed
+    SYS := $(shell gcc -dumpmachine)
+    ifeq ($(findstring cygwin, $(SYS)),cygwin)
+      PLATFORM = cygwin
+    endif
+    ifeq ($(findstring mingw32, $(SYS)),mingw32)
+      PLATFORM = mingw32
+    endif
+    ifeq ($(findstring mingw64, $(SYS)),mingw64)
+      PLATFORM = mingw64
+    endif
 else
     # Grab the output of `uname -s` and switch to set the platform
     UNAME_S := $(shell uname -s)
-    UNAME_O := $(shell uname -o)
     ifeq ($(UNAME_S),Linux)
         PLATFORM = unix
     endif
@@ -23,14 +31,11 @@ else
     ifeq ($(UNAME_S),SunOS)
         PLATFORM = sunos
     endif
-    ifeq ($(UNAME_O),Cygwin)
-        PLATFORM = cygwin
-    endif
+endif
 
-    # Verify that the PLATFORM was detected
-    ifndef PLATFORM
-        $(error Autodetection of platform failed, please use appropriate .mak file)
-    endif
+# Verify that the PLATFORM was detected
+ifndef PLATFORM
+    $(error Autodetection of platform failed, please use appropriate .mak file)
 endif
 
 # Invoke the platform specific make files

--- a/README.mkd
+++ b/README.mkd
@@ -59,6 +59,9 @@ make
 
 Note: You must use GNU make to build vimproc.
 
+You can install the dll using |VimProcInstall|. If you are having any trouble
+or want to build manually then read on.
+
 ### Linux
 
     $ make

--- a/doc/vimproc.txt
+++ b/doc/vimproc.txt
@@ -57,6 +57,9 @@ vimproc_cygwin.dll)".  Because vimproc depends on "vimproc_xxx.so (or
 vimproc_win32.dll, vimproc_cygwin.dll)"'s function, vimproc echoes error
 message when "vimproc_xxx.so (vimproc_xxx.dll)" doesn't exist.
 
+You can install the dll using |VimProcInstall|. If you are having any trouble
+or want to build manually then read on.
+
 Note: The vimproc_cygwin.dll compiled in Cygwin won't work with Windows Vim.
 
 Supported platforms:
@@ -180,6 +183,11 @@ COMMANDS 					*vimproc-commands*
 :VimProcRead {path}					*:VimProcRead*
 			Executes {path} command and paste result in current
 			buffer.  This command replaces |:read|.
+
+:VimProcInstall {args}				        *:VimProcInstall*
+			Tries to build the necessary dll using `gmake`/`make`.
+			You can supply extra arguments to `make`, for example
+			to compile using clang `:VimProcInstall CC=clang`.
 
 ------------------------------------------------------------------------------
 FUNCTIONS 					*vimproc-functions*


### PR DESCRIPTION
The Makefile will be updated to detect Cygwin/Mingw to properly support a Windows environment. It the uses this to add a new command to allow easier installation/updating.

Most of the detecting was take from a [stackoverflow question][1]. This will fix #186 if it works. I don't have a windows machine available, so please test this. I also have no idea how to write test cases for a vim plugin, so any help there would be very much appreciated.

[1]: https://stackoverflow.com/questions/714100/os-detecting-makefile