### PR TITLE
Propagate compilation flags from environment vars.

### DIFF
--- a/make_cygwin.mak
+++ b/make_cygwin.mak
@@ -1,4 +1,4 @@
-CFLAGS=-O2 -W -Wall -Wno-unused -Wno-unused-parameter -use=gnu99 -shared
+CFLAGS+=-O2 -W -Wall -Wno-unused -Wno-unused-parameter -use=gnu99 -shared
 TARGET=autoload/vimproc_cygwin.dll
 SRC=autoload/proc.c
 LDFLAGS+=-lutil

--- a/make_mac.mak
+++ b/make_mac.mak
@@ -13,7 +13,7 @@ endif
 TARGET=autoload/vimproc_mac.so
 SRC=autoload/proc.c
 ARCHS=
-CFLAGS=-O2 -W -Wall -Wno-unused -Wno-unused-parameter -bundle -fPIC $(foreach ARCH,$(ARCHS),-arch $(ARCH))
+CFLAGS+=-O2 -W -Wall -Wno-unused -Wno-unused-parameter -bundle -fPIC $(foreach ARCH,$(ARCHS),-arch $(ARCH))
 LDFLAGS=
 
 all: $(TARGET)

--- a/make_mingw32.mak
+++ b/make_mingw32.mak
@@ -3,7 +3,7 @@
 TARGET=autoload/vimproc_win32.dll
 SRC=autoload/proc_w32.c
 CC=gcc
-CFLAGS=-O2 -Wall -shared -m32
+CFLAGS+=-O2 -Wall -shared -m32
 LDFLAGS+=-lwsock32
 
 all: $(TARGET)

--- a/make_mingw64.mak
+++ b/make_mingw64.mak
@@ -3,7 +3,7 @@
 TARGET=autoload/vimproc_win64.dll
 SRC=autoload/proc_w32.c
 CC=x86_64-w64-mingw32-gcc
-CFLAGS=-O2 -Wall -shared -m64
+CFLAGS+=-O2 -Wall -shared -m64
 LDFLAGS+=-lwsock32
 
 all: $(TARGET)

--- a/make_sunos.mak
+++ b/make_sunos.mak
@@ -2,14 +2,14 @@
 
 ifneq ($(SUNCC),)
 CC=$(SUNCC)
-CFLAGS=-errwarn -xc99 -xO3 -native -KPIC
-LDFLAGS=-G
+CFLAGS+=-errwarn -xc99 -xO3 -native -KPIC
+LDFLAGS+=-G
 else # gcc
 CC=gcc
-CFLAGS=-W -Wall -Wno-unused -Wno-unused-parameter -std=c99 -O2 -fPIC -pedantic
-LDFLAGS=-shared
+CFLAGS+=-W -Wall -Wno-unused -Wno-unused-parameter -std=c99 -O2 -fPIC -pedantic
+LDFLAGS+=-shared
 endif
-CPPFLAGS=-D_XPG6 -D__EXTENSIONS__
+CPPFLAGS+=-D_XPG6 -D__EXTENSIONS__
 
 TARGET=autoload/vimproc_unix.so
 SRC=autoload/proc.c autoload/ptytty.c

--- a/make_unix.mak
+++ b/make_unix.mak
@@ -8,8 +8,8 @@ endif
 TARGET=autoload/vimproc_$(SUFFIX).so
 
 SRC=autoload/proc.c
-CFLAGS=-W -O2 -Wall -Wno-unused -Wno-unused-parameter -std=gnu99 -pedantic -shared -fPIC
-LDFLAGS=-lutil
+CFLAGS+=-W -O2 -Wall -Wno-unused -Wno-unused-parameter -std=gnu99 -pedantic -shared -fPIC
+LDFLAGS+=-lutil
 
 all: $(TARGET)
 


### PR DESCRIPTION
This allows to set initial compilation flags in environment variables
(e.g. CFLAGS) to control compilation.