### PR TITLE
Fixed glob() use for Linux DL discovery

### DIFF
--- a/autoload/vimproc.vim
+++ b/autoload/vimproc.vim
@@ -57,9 +57,9 @@ elseif vimproc#util#is_cygwin()
   let s:vimproc_dll_basename = 'vimproc_cygwin.dll'
 elseif vimproc#util#is_mac()
   let s:vimproc_dll_basename = 'vimproc_mac.so'
-elseif glob('/lib*/ld-linux*64.so.2') != ''
+elseif glob('/lib*/ld-linux*64.so.2',1) != ''
   let s:vimproc_dll_basename = 'vimproc_linux64.so'
-elseif glob('/lib*/ld-linux*.so.2') != ''
+elseif glob('/lib*/ld-linux*.so.2',1) != ''
   let s:vimproc_dll_basename = 'vimproc_linux32.so'
 else
   let s:vimproc_dll_basename = 'vimproc_unix.so'


### PR DESCRIPTION
During dynamic library detection on Linux, glob() was used without its second argument, therefore not ignoring wildignore and failing to find the correct Linux library when wildignore contained e.g. "*.so.*"

Fixes issue #190 