### PR TITLE
Support *BSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,19 +17,19 @@ else
         PLATFORM = unix
     endif
     ifeq ($(UNAME_S),FreeBSD)
-        MAKE = make
+        MAKE = make # BSD Make
         PLATFORM = bsd
     endif
     ifeq ($(UNAME_S),DragonFly)
-        MAKE = make
+        MAKE = make # BSD Make
         PLATFORM = bsd
     endif
     ifeq ($(UNAME_S),NetBSD)
-        MAKE = make
+        MAKE = make # BSD Make
         PLATFORM = bsd
     endif
     ifeq ($(UNAME_S),OpenBSD)
-        MAKE = make
+        MAKE = make # BSD Make
         PLATFORM = bsd
     endif
     ifeq ($(UNAME_S),Darwin)

--- a/Makefile
+++ b/Makefile
@@ -17,15 +17,19 @@ else
         PLATFORM = unix
     endif
     ifeq ($(UNAME_S),FreeBSD)
+        MAKE = make
         PLATFORM = bsd
     endif
     ifeq ($(UNAME_S),DragonFly)
+        MAKE = make
         PLATFORM = bsd
     endif
     ifeq ($(UNAME_S),NetBSD)
+        MAKE = make
         PLATFORM = bsd
     endif
     ifeq ($(UNAME_S),OpenBSD)
+        MAKE = make
         PLATFORM = bsd
     endif
     ifeq ($(UNAME_S),Darwin)

--- a/Makefile
+++ b/Makefile
@@ -17,16 +17,16 @@ else
         PLATFORM = unix
     endif
     ifeq ($(UNAME_S),FreeBSD)
-        PLATFORM = unix
+        PLATFORM = bsd
     endif
     ifeq ($(UNAME_S),DragonFly)
-        PLATFORM = unix
+        PLATFORM = bsd
     endif
     ifeq ($(UNAME_S),NetBSD)
-        PLATFORM = unix
+        PLATFORM = bsd
     endif
     ifeq ($(UNAME_S),OpenBSD)
-        PLATFORM = unix
+        PLATFORM = bsd
     endif
     ifeq ($(UNAME_S),Darwin)
         PLATFORM = mac

--- a/autoload/vimproc.vim
+++ b/autoload/vimproc.vim
@@ -60,6 +60,8 @@ elseif glob('/lib*/ld-linux*64.so.2',1) != ''
   let s:vimproc_dll_basename = 'vimproc_linux64.so'
 elseif glob('/lib*/ld-linux*.so.2',1) != ''
   let s:vimproc_dll_basename = 'vimproc_linux32.so'
+elseif system('uname -s') =~? '^.+BSD$'
+  let s:vimproc_dll_basename = system('uname -sm | tr "[:upper:]" "[:lower:]" | sed -e "s/ /_/" | xargs -I "{}" echo vimproc_{}.so')
 else
   let s:vimproc_dll_basename = 'vimproc_unix.so'
 endif

--- a/autoload/vimproc.vim
+++ b/autoload/vimproc.vim
@@ -60,7 +60,7 @@ elseif glob('/lib*/ld-linux*64.so.2',1) != ''
   let s:vimproc_dll_basename = 'vimproc_linux64.so'
 elseif glob('/lib*/ld-linux*.so.2',1) != ''
   let s:vimproc_dll_basename = 'vimproc_linux32.so'
-elseif system('uname -s') =~? '^.\+BSD\n$'
+elseif (!has('win32unix')) && has('unix') && system('uname -s') =~? '^.\+BSD\n$'
   let s:vimproc_dll_basename = system('uname -sm | tr "[:upper:]" "[:lower:]" | sed -e "s/ /_/" | xargs -I "{}" echo vimproc_{}.so')[0 : -2]
 else
   let s:vimproc_dll_basename = 'vimproc_unix.so'

--- a/autoload/vimproc.vim
+++ b/autoload/vimproc.vim
@@ -60,8 +60,8 @@ elseif glob('/lib*/ld-linux*64.so.2',1) != ''
   let s:vimproc_dll_basename = 'vimproc_linux64.so'
 elseif glob('/lib*/ld-linux*.so.2',1) != ''
   let s:vimproc_dll_basename = 'vimproc_linux32.so'
-elseif system('uname -s') =~? '^.+BSD$'
-  let s:vimproc_dll_basename = system('uname -sm | tr "[:upper:]" "[:lower:]" | sed -e "s/ /_/" | xargs -I "{}" echo vimproc_{}.so')
+elseif system('uname -s') =~? '^.\+BSD\n$'
+  let s:vimproc_dll_basename = system('uname -sm | tr "[:upper:]" "[:lower:]" | sed -e "s/ /_/" | xargs -I "{}" echo vimproc_{}.so')[0 : -2]
 else
   let s:vimproc_dll_basename = 'vimproc_unix.so'
 endif

--- a/make_bsd.mak
+++ b/make_bsd.mak
@@ -1,0 +1,17 @@
+# for *BSD platform.
+
+SUFFIX!=uname -sm | tr '[:upper:]' '[:lower:]' | sed -e 's/ /_/'
+
+TARGET=autoload/vimproc_$(SUFFIX).so
+
+SRC=autoload/proc.c
+CFLAGS+=-W -O2 -Wall -Wno-unused -Wno-unused-parameter -std=gnu99 -pedantic -shared -fPIC
+LDFLAGS+=-lutil
+
+all: $(TARGET)
+
+$(TARGET): $(SRC) autoload/vimstack.c
+	$(CC) $(CFLAGS) -o $(TARGET) $(SRC) $(LDFLAGS)
+
+clean:
+	rm -f $(TARGET)


### PR DESCRIPTION
I'm FreeBSD user, so I've checked on only FreeBSD.

- add `make_bsd.mak`
    - it's for BSD Make
    - `.so` file is named `vimproc_os_arch.so`; for example `vimproc_freebsd_amd64.so` in my system
- `autoload/vimproc.vim` detects `.so`'s file path that is named above
- `Makefile` expects to be launched by GNU Make `gmake`, and run `make -f make_bsd.mak` that is BSD Make

The reason of using BSD Make is for plugin managers. If using just `make -f make_bsd.mak`, GNU Make is not needed.