### PR TITLE
Add appveyor.yml to build DLL for MS Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+---
+version: '{build}'
+shallow_clone: true
+environment:
+  matrix:
+  - CPU: i386
+    ENV: /x86
+  - CPU: AMD64
+    ENV: /x64
+install:
+  - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" %ENV%'
+build_script:
+  - nmake -f make_msvc.mak nodebug=1 CPU=%CPU%
+artifacts:
+  - path: autoload/vimproc_*.dll
+    name: vimproc.dll
+deploy:
+  provider: GitHub
+  description: vimproc
+  auth_token:
+    secure: <token secret here>
+  on:
+    appveyor_repo_tag: true


### PR DESCRIPTION
AppVeyor で Windows 用の DLL をビルドし、その DLL を GitHub Releases に自動でアップロードするための設定です。

## 注意: この PR をマージしただけでは動きません。以下の設定が必要です。

1. AppVeyor にログインします。(https://ci.appveyor.com/login)
   GitHub アカウントでログインしてください。

2. プロジェクト一覧ページの + NEW PROJECT から新しいプロジェクトを追加します。
   GitHub のリポジトリ一覧が表示されるので、vimproc.vim を選んで + ADD を押します。

3. GitHub で Personal Access Token を生成します。
   https://github.com/settings/tokens
   1. Generate new token を押します。
   2. Token Description に自分があとから見てわかる説明文を、チェックボックスは `public_repo` のみを入れて、 `Generate Token` を押します。
   3. 生成された Access Token をメモします。(ページをリロードすると消えるので注意。わからなくなった場合は再生成してください)
   4. AppVeyor の右上のメニューから、`Encrypt Data` を選択します。
   5. `Value to encrypt` テキストボックスに先ほど生成した Access Token を入れて、`Encrypt` を押します。
   6. 生成されたデータを、YAML 内の `<token secret here>` の部分に入れます。

以上の設定を行うことで、GitHub にタグを push する度に、自動でバイナリが生成されて GitHub Releases にアップロードされます。

あとからファイルを変更しないといけないので、この PR を直接使っても、ファイルだけ使って別コミットでやってもどちらでも大丈夫です。