### PR TITLE
[WIP] Enable test on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,3 +35,4 @@ deploy:
     secure: rKd6JLXUIl3vcA8d0S9w14bl+uvUlZLt0d1M8bmlOh+owQqr5c40+/4ITCNBpHG3
   on:
     appveyor_repo_tag: true
+    COMPILER: msvc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,12 +5,20 @@ environment:
   matrix:
   - CPU: i386
     ENV: /x86
+    BIT: 32
   - CPU: AMD64
     ENV: /x64
+    BIT: 64
 install:
   - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" %ENV%'
+  - curl http://files.kaoriya.net/vim/vim74-kaoriya-win%BIT%.zip -s -o vim.zip
+  - unzip -q vim.zip
+  - git clone -q https://github.com/thinca/vim-themis.git themis --depth=1
+  - set THEMIS_VIM=%APPVEYOR_BUILD_FOLDER%\vim74-kaoriya-win%BIT%\vim.exe
 build_script:
   - nmake -f make_msvc.mak nodebug=1 CPU=%CPU%
+test_script:
+  - themis\bin\themis
 artifacts:
   - path: autoload/vimproc_*.dll
     name: vimproc.dll

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,23 +2,29 @@
 version: '{build}'
 shallow_clone: true
 environment:
+  global:
+    MSYS2_BASEVER: 20150916
   matrix:
-  - CPU: i386
+  - COMPILER: msvc
+    CPU: i386
     ENV: /x86
     BIT: 32
-  - CPU: AMD64
+  - COMPILER: msvc
+    CPU: AMD64
     ENV: /x64
     BIT: 64
-install:
-  - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" %ENV%'
-  - appveyor DownloadFile http://files.kaoriya.net/vim/vim74-kaoriya-win%BIT%.zip -FileName vim.zip
-  - 7z x vim.zip > nul
-  - git clone -q https://github.com/thinca/vim-themis.git themis --depth=1
-  - set THEMIS_VIM=%APPVEYOR_BUILD_FOLDER%\vim74-kaoriya-win%BIT%\vim.exe
+  - COMPILER: cygwin
+  - COMPILER: mingw
+    BIT: 32
+  - COMPILER: msys2
+    MSYS2_ARCH: x86_64
+    MSYS2_DIR: msys64
+    MSYSTEM: MINGW64
+    BIT: 64
 build_script:
-  - nmake -f make_msvc.mak nodebug=1 CPU=%CPU%
+  - '%APPVEYOR_BUILD_FOLDER%\tools\appveyor.bat'
 test_script:
-  - themis\bin\themis
+  - '%APPVEYOR_BUILD_FOLDER%\tools\appveyor.bat test'
 artifacts:
   - path: autoload/vimproc_*.dll
     name: vimproc.dll

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,8 @@ environment:
     BIT: 64
 install:
   - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" %ENV%'
-  - curl http://files.kaoriya.net/vim/vim74-kaoriya-win%BIT%.zip -s -o vim.zip
-  - unzip -q vim.zip
+  - appveyor DownloadFile http://files.kaoriya.net/vim/vim74-kaoriya-win%BIT%.zip -FileName vim.zip
+  - 7z x vim.zip > nul
   - git clone -q https://github.com/thinca/vim-themis.git themis --depth=1
   - set THEMIS_VIM=%APPVEYOR_BUILD_FOLDER%\vim74-kaoriya-win%BIT%\vim.exe
 build_script:

--- a/test/popen.vim
+++ b/test/popen.vim
@@ -8,7 +8,7 @@ function! s:suite.popen2()
   endif
 
   if vimproc#util#is_windows()
-    let cmd = ['DIR', '/B']
+    let cmd = ['cmd', '/c', 'DIR', '/B']
   else
     let cmd = ['ls']
   endif
@@ -36,7 +36,7 @@ function! s:suite.popen2()
   unlet sub
 
   if vimproc#util#is_windows()
-    let cmd = ['DIR', '/B', '/A']
+    let cmd = ['cmd', '/c', 'DIR', '/B', '/A']
   else
     let cmd = ['ls', '-la']
   endif
@@ -66,7 +66,7 @@ endfunction
 
 function! s:suite.popen3()
   if vimproc#util#is_windows()
-    let cmd = ['DIR', '/B']
+    let cmd = ['cmd', '/c', 'DIR', '/B']
   else
     let cmd = ['ls']
   endif

--- a/test/popen.vim
+++ b/test/popen.vim
@@ -97,6 +97,7 @@ endfunction
 function! s:suite.redirection1()
   let output = vimproc#system('echo "foo" > test.txt | echo "bar"')
   call s:assert.equals(output, "bar\n")
+  sleep 3
   call s:assert.equals(readfile('test.txt'), ['foo'])
   if filereadable('test.txt')
     call delete('test.txt')
@@ -111,6 +112,7 @@ function! s:suite.redirection2()
   endwhile
   " Newline conversion.
   let res = substitute(res, '\r\n', '\n', 'g')
+  sleep 3
   call s:assert.equals(readfile('test.txt'), ['foo'])
   if filereadable('test.txt')
     call delete('test.txt')

--- a/test/system.vim
+++ b/test/system.vim
@@ -17,23 +17,21 @@ function! s:suite.system2()
   call s:assert.equals(vimproc#system(['ls']), system('ls'))
 endfunction
 
-function! s:suite.system3()
+function! s:suite.cmd_system1()
   call s:check_ls()
   call s:assert.equals(vimproc#cmd#system('ls'), system('ls'))
 endfunction
 
-function! s:suite.system4()
+function! s:suite.cmd_system2()
   call s:check_ls()
   call s:assert.equals(vimproc#cmd#system(['ls']), system('ls'))
 endfunction
 
-if has('win32') || has('win64')
-  function! s:suite.cmd_system()
-    call s:assert.equals(
-          \ vimproc#cmd#system(['echo', '"Foo"']),
-          \ system('echo "Foo"'))
-  endfunction
-endif
+function! s:suite.cmd_system3()
+  call s:assert.equals(
+        \ vimproc#cmd#system(['echo', '"Foo"']),
+        \ system('echo "Foo"'))
+endfunction
 
 function! s:suite.system_passwd1()
   call s:assert.equals(

--- a/test/system.vim
+++ b/test/system.vim
@@ -30,16 +30,22 @@ endfunction
 function! s:suite.cmd_system3()
   call s:assert.equals(
         \ vimproc#cmd#system(['echo', '"Foo"']),
-        \ system('echo "Foo"'))
+        \ "\"Foo\"\n")
 endfunction
 
 function! s:suite.system_passwd1()
+  if vimproc#util#is_windows()
+    call s:assert.skip('')
+  endif
   call s:assert.equals(
         \ vimproc#system_passwd('echo -n test'),
         \ system('echo -n test'))
 endfunction
 
 function! s:suite.system_passwd2()
+  if vimproc#util#is_windows()
+    call s:assert.skip('')
+  endif
   call s:assert.equals(
         \ vimproc#system_passwd(['echo', '-n', 'test']),
         \ system('echo -n test'))

--- a/tools/appveyor.bat
+++ b/tools/appveyor.bat
@@ -100,14 +100,8 @@ goto :eof
 
 :cygwin_test
 @echo on
-bash -lc "git clone -q https://github.com/thinca/vim-themis.git themis --depth=1"
-bash -lc "themis/bin/themis test/fopen.vim"
-bash -lc "themis/bin/themis test/functions.vim"
-bash -lc "themis/bin/themis test/lexer.vim"
-bash -lc "themis/bin/themis test/parser.vim"
-bash -lc "themis/bin/themis test/popen.vim"
-bash -lc "themis/bin/themis test/socket.vim"
-bash -lc "themis/bin/themis test/system.vim"
+rem bash -lc "git clone -q https://github.com/thinca/vim-themis.git themis --depth=1"
+rem bash -lc "themis/bin/themis"
 
 @echo off
 goto :eof

--- a/tools/appveyor.bat
+++ b/tools/appveyor.bat
@@ -1,0 +1,124 @@
+@echo off
+:: Batch file for building/testing vimproc on AppVeyor
+
+cd %APPVEYOR_BUILD_FOLDER%
+if /I "%1"=="test" (
+  set _target=_test
+) else (
+  set _target=
+)
+
+for %%i in (msvc mingw msys2 cygwin) do if "%compiler%"=="%%i" goto %compiler%%_target%
+
+echo Unknown build target.
+exit 1
+
+:msvc
+:: ----------------------------------------------------------------------
+:: Using VC10 with nmake
+::call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" %ARCH%
+call :install_vim
+call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" %ENV%
+
+@echo on
+nmake -f make_msvc.mak nodebug=1 CPU=%CPU%
+
+@echo off
+goto :eof
+
+:msvc_test
+set THEMIS_VIM=%APPVEYOR_BUILD_FOLDER%\vim74-kaoriya-win%BIT%\vim.exe
+@echo on
+themis\bin\themis
+
+@echo off
+goto :eof
+
+
+:mingw
+:: ----------------------------------------------------------------------
+:: Using MinGW
+call :install_vim
+@echo on
+path C:\MinGW\bin;C:\MinGW\msys\1.0\bin;%path%
+make -f make_mingw32.mak
+
+@echo off
+goto :eof
+
+:mingw_test
+set THEMIS_VIM=%APPVEYOR_BUILD_FOLDER%\vim74-kaoriya-win%BIT%\vim.exe
+@echo on
+themis\bin\themis
+
+@echo off
+goto :eof
+
+
+:msys2
+:: ----------------------------------------------------------------------
+:: Using MSYS2
+call :install_vim
+@echo on
+:: Install MSYS2
+appveyor DownloadFile "http://repo.msys2.org/distrib/%MSYS2_ARCH%/msys2-base-%MSYS2_ARCH%-%MSYS2_BASEVER%.tar.xz" -FileName "msys2.tar.xz"
+c:\cygwin\bin\xz -dc msys2.tar.xz | c:\cygwin\bin\tar xf -
+
+PATH %APPVEYOR_BUILD_FOLDER%\%MSYS2_DIR%\%MSYSTEM%\bin;%APPVEYOR_BUILD_FOLDER%\%MSYS2_DIR%\usr\bin;%PATH%
+set CHERE_INVOKING=yes
+bash -lc ""
+:: Install and update necessary packages
+bash -lc "for i in {1..3}; do update-core && break || sleep 15; done"
+bash -lc "for i in {1..3}; do pacman --noconfirm -Su mingw-w64-%MSYS2_ARCH%-{gcc,libiconv} automake autoconf make dos2unix && break || sleep 15; done"
+
+bash -lc "make -f make_mingw%BIT%.mak"
+
+@echo off
+goto :eof
+
+:msys2_test
+set THEMIS_VIM=%APPVEYOR_BUILD_FOLDER%\vim74-kaoriya-win%BIT%\vim.exe
+@echo on
+themis\bin\themis
+
+@echo off
+goto :eof
+
+
+:cygwin
+:: ----------------------------------------------------------------------
+:: Using Cygwin
+@echo on
+c:\cygwin\setup-x86.exe -qnNdO -R C:/cygwin -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P vim
+PATH c:\cygwin\bin;%PATH%
+set CHERE_INVOKING=yes
+bash -lc ""
+bash -lc "make"
+
+@echo off
+goto :eof
+
+:cygwin_test
+@echo on
+bash -lc "git clone -q https://github.com/thinca/vim-themis.git themis --depth=1"
+bash -lc "themis/bin/themis test/fopen.vim"
+bash -lc "themis/bin/themis test/functions.vim"
+bash -lc "themis/bin/themis test/lexer.vim"
+bash -lc "themis/bin/themis test/parser.vim"
+bash -lc "themis/bin/themis test/popen.vim"
+bash -lc "themis/bin/themis test/socket.vim"
+bash -lc "themis/bin/themis test/system.vim"
+
+@echo off
+goto :eof
+
+
+:install_vim
+:: ----------------------------------------------------------------------
+:: Install Vim and themis
+echo Downloading Vim
+appveyor DownloadFile http://files.kaoriya.net/vim/vim74-kaoriya-win%BIT%.zip -FileName vim.zip
+echo Installing Vim
+7z x vim.zip > nul
+git clone -q https://github.com/thinca/vim-themis.git themis --depth=1
+exit /b


### PR DESCRIPTION
AppVeyor is now enabled by #217. It's good time also to enable test on AppVeyor.

TODO:

* [x] Make all tests pass on AppVeyor
* [ ] Enable test on Cygwin
* [x] Enable test on MinGW or MSYS2

Note:
This PR is still work in progress. Do not merge yet.
~~test/functions.vim is disabled temporarily.~~