### PR TITLE
appveyor: Use preinstalled MSYS2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,14 @@ ifeq ($(OS),Windows_NT)
     # Need to figure out if Cygwin/Mingw is installed
     SYS := $(shell gcc -dumpmachine)
     ifeq ($(findstring cygwin, $(SYS)),cygwin)
-      PLATFORM = cygwin
+        PLATFORM = cygwin
     endif
-    ifeq ($(findstring mingw32, $(SYS)),mingw32)
-      PLATFORM = mingw32
-    endif
-    ifeq ($(findstring mingw64, $(SYS)),mingw64)
-      PLATFORM = mingw64
+    ifeq ($(findstring mingw, $(SYS)),mingw)
+        ifeq ($(findstring x86_64, $(SYS)),x86_64)
+            PLATFORM = mingw64
+        else
+            PLATFORM = mingw32
+        endif
     endif
 else
     # Grab the output of `uname -s` and switch to set the platform

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,6 @@
 version: '{build}'
 shallow_clone: true
 environment:
-  global:
-    MSYS2_BASEVER: 20150916
   matrix:
   - COMPILER: msvc
     CPU: i386

--- a/tools/appveyor.bat
+++ b/tools/appveyor.bat
@@ -69,7 +69,7 @@ set CHERE_INVOKING=yes
 bash -lc ""
 :: Install and update necessary packages
 bash -lc "for i in {1..3}; do update-core && break || sleep 15; done"
-bash -lc "for i in {1..3}; do pacman --noconfirm -Su mingw-w64-%MSYS2_ARCH%-{gcc,libiconv} automake autoconf make dos2unix && break || sleep 15; done"
+bash -lc "for i in {1..3}; do pacman --noconfirm -Su mingw-w64-%MSYS2_ARCH%-{gcc,make} make && break || sleep 15; done"
 
 bash -lc "make"
 

--- a/tools/appveyor.bat
+++ b/tools/appveyor.bat
@@ -62,10 +62,9 @@ call :install_vim
 @echo on
 PATH C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%
 set CHERE_INVOKING=yes
-bash -lc ""
 :: Install and update necessary packages
-bash -lc "for i in {1..3}; do update-core && break || sleep 15; done"
-bash -lc "for i in {1..3}; do pacman --noconfirm -Su mingw-w64-%MSYS2_ARCH%-{gcc,make} make && break || sleep 15; done"
+rem bash -lc "for i in {1..3}; do update-core && break || sleep 15; done"
+rem bash -lc "for i in {1..3}; do pacman --noconfirm -Su mingw-w64-%MSYS2_ARCH%-{gcc,make} make && break || sleep 15; done"
 
 bash -lc "make"
 

--- a/tools/appveyor.bat
+++ b/tools/appveyor.bat
@@ -71,7 +71,7 @@ bash -lc ""
 bash -lc "for i in {1..3}; do update-core && break || sleep 15; done"
 bash -lc "for i in {1..3}; do pacman --noconfirm -Su mingw-w64-%MSYS2_ARCH%-{gcc,libiconv} automake autoconf make dos2unix && break || sleep 15; done"
 
-bash -lc "make -f make_mingw%BIT%.mak"
+bash -lc "make"
 
 @echo off
 goto :eof

--- a/tools/appveyor.bat
+++ b/tools/appveyor.bat
@@ -60,11 +60,7 @@ goto :eof
 :: Using MSYS2
 call :install_vim
 @echo on
-:: Install MSYS2
-appveyor DownloadFile "http://repo.msys2.org/distrib/%MSYS2_ARCH%/msys2-base-%MSYS2_ARCH%-%MSYS2_BASEVER%.tar.xz" -FileName "msys2.tar.xz"
-c:\cygwin\bin\xz -dc msys2.tar.xz | c:\cygwin\bin\tar xf -
-
-PATH %APPVEYOR_BUILD_FOLDER%\%MSYS2_DIR%\%MSYSTEM%\bin;%APPVEYOR_BUILD_FOLDER%\%MSYS2_DIR%\usr\bin;%PATH%
+PATH C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%
 set CHERE_INVOKING=yes
 bash -lc ""
 :: Install and update necessary packages


### PR DESCRIPTION
いつの間にかAppVeyorにMSYS2がインストールされていましたので、それを使うように変更しています。
64bit版MinGWの判定に間違いがあったので、それも併せて修正しています。