### PR TITLE
modify gcc -> '$(CC)' for make_cygwin.mak

### DIFF
--- a/make_cygwin.mak
+++ b/make_cygwin.mak
@@ -6,7 +6,7 @@ LDFLAGS+=-lutil
 all: $(TARGET)
 
 $(TARGET): $(SRC) src/vimstack.c
-	gcc $(CFLAGS) -o $(TARGET) $(SRC) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $(TARGET) $(SRC) $(LDFLAGS)
 
 clean:
 	rm -f $(TARGET)


### PR DESCRIPTION
make_cygwin.makの9行目で使われているgccを$(CC)に変更しました。
旧：9	gcc $(CFLAGS) -o $(TARGET) $(SRC) $(LDFLAGS)
新：9	$(CC) $(CFLAGS) -o $(TARGET) $(SRC) $(LDFLAGS)

make_cygwin.makはMSYS2でもビルドでも使われますが，gccコマンドだと問題が起こるためMakefileで既定でccとなっている$（CC)を使うほうが望ましいです。

変更の理由を簡単に述べると以下3点です。

1. MSYS2のMinGWビルド環境でgccはx86_64-w64-mingw32-gcc.exeであるためビルドに失敗する。
2. Cygwinではccコマンドは/usr/bin/gccへのシンボリックリンクであるため変更に対してデメリットがない。
3. $(CC)というように変数にすることでユーザーがmake実行時にコンパイルコマンドを上書きでき，柔軟性が高い。


1.について説明します。

MinGWのビルド環境である［MinGW-w64 Win64 Shell］と［MinGW-w64 Win32 Shell］から起動するとPATHが/mingw64/binか/mingw32/binが優先され，gccコマンドは実質的にはx86_64-w64-mingw32-gcc.exeやi686-w64-mingw32-gcc.exeとなってしまいます。
したがって，MinGW環境のMSYS2だとgccはx86_64-w64-mingw32-gcc.exeやi686-w64-mingw32-gcc.exeであるためvimprocのdllのビルドに失敗します。
MinGWのビルド環境でこれを回避するため，make_cygwin.makでのコンパイラはccコマンドである必要があります。もちろん，MSYSのビルド環境であればgccは通常のgccであり，この問題はおきません。

2.について説明します。

Cygwinにおいてはccコマンドは/usr/bin/gccへのシンボリックリンクであるため，この変更による問題は起きないと思います。万が一，変更を恐れるのであれば，事前にmake_cygwin.makでCC=gccによりCC変数をgccにすることで現状と同一の動作が可能です。


3.について説明します。

他の.makファイルは$(CC)変数を使い，コンパイル時のコマンドをmake実行時にユーザーが上書きできるようになっています。しかし，make_cygwin.makだけgccコマンドを以下のように直書きしており，ユーザーが上書きできません。$(CC)変数にすることで，以下のようにユーザーがコンパイルコマンドを指定でき柔軟に対応可能です。
CC=x86_64-w64-mingw32-gcc.exe make -f make_cygwin.mak

以上の理由により改良を施しPull Requestを差し上げました。gcc→$(CC)の変更に問題があると思わるのでしたら，以下のように他の.makファイルと同じようにしてCC変数でgccを指定いただく形に変更いただけませんでしょうか？

CC=gcc
$(CC) $(CFLAGS) -o $(TARGET) $(SRC) $(LDFLAGS)

ご検討どうぞよろしくお願いします。