### PR TITLE
fixed vimproc dll not found error on FreeBSD

### DIFF
--- a/autoload/vimproc.vim
+++ b/autoload/vimproc.vim
@@ -63,7 +63,7 @@ elseif glob('/lib*/ld-linux*.so.2',1) != ''
 elseif system('uname -s') =~? '^.\+BSD\n$'
   let s:vimproc_dll_basename = system(
         \ 'uname -sm | tr "[:upper:]" "[:lower:]"'
-        \ .' | sed -e "s/ /_/" | xargs -I "{}" echo vimproc_{}.so')[0 : -2]
+        \ .' | sed -e "s/ /_/" | xargs -I "{}" echo "vimproc_{}.so"')[0 : -2]
 else
   let s:vimproc_dll_basename = 'vimproc_unix.so'
 endif


### PR DESCRIPTION
fixed error on FreeBSD where vimproc could not load correct library.

Error message was:
[vimproc] vimproc's DLL: "~/.vim/bundle/vimproc.vim/lib/vimproc_.so" is not found.
