### PR TITLE
fix compiler name for cygwin

### DIFF
--- a/make_cygwin.mak
+++ b/make_cygwin.mak
@@ -1,3 +1,4 @@
+CC=gcc
 CFLAGS+=-O2 -W -Wall -Wno-unused -Wno-unused-parameter -use=gnu99 -shared
 TARGET=lib/vimproc_cygwin.dll
 SRC=src/proc.c


### PR DESCRIPTION
On my machine, `$(CC)` defaults to `cc`, which is the wrong name. By explicitly configuring the name as `gcc`, then cygwin compilation can now succeed.