### PR TITLE
change the compiler to gmake on freebsd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ else
         PLATFORM = unix
     endif
     ifeq ($(UNAME_S),FreeBSD)
-        MAKE = make # BSD Make
+        MAKE = gmake # BSD Make
         PLATFORM = bsd
     endif
     ifeq ($(UNAME_S),DragonFly)


### PR DESCRIPTION
The make on freebsd does not compile the vimproc, In my tests, I created a alias to make=gmake to solve this problem.
It's happen on FreeBSD 12.