### PR TITLE
Track the lib/.gitkeep file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 lib/*
+!lib/.gitkeep
 doc/tags
 *.obj
 *.o


### PR DESCRIPTION
The lib/.gitkeep file should be tracked by git.

I found this issue for I failed to run make when I setup a SpaceVim in new machines (Linux and MacOS), they have the same issue for missing folder `lib`.

Here is error message:
```
# bright @ shacng035wqrt in ~/.SpaceVim/bundle/vimproc.vim on git:master o [13:25:35]
$ make
make -f make_unix.mak
make[1]: Entering directory '/home/bright/.SpaceVim/bundle/vimproc.vim'
cc -W -O2 -Wall -Wno-unused -Wno-unused-parameter -std=gnu99 -pedantic -shared -fPIC  -o lib/vimproc_linux64.so src/proc.c -lutil
/usr/bin/ld: cannot open output file lib/vimproc_linux64.so: No such file or directory
collect2: error: ld returned 1 exit status
make[1]: *** [make_unix.mak:17: lib/vimproc_linux64.so] Error 1
make[1]: Leaving directory '/home/bright/.SpaceVim/bundle/vimproc.vim'
make: *** [Makefile:66: all] Error 2
```

I know SpaceVim used this repo, so I have a same fix in SpaceVim.
https://github.com/SpaceVim/SpaceVim/pull/3586