### PR TITLE
add arm64 to mac fat-binary

### DIFF
--- a/make_mac.mak
+++ b/make_mac.mak
@@ -12,7 +12,7 @@ endif
 
 TARGET=lib/vimproc_mac.so
 SRC=src/proc.c
-ARCHS=x86_64 arm64e
+ARCHS=x86_64 arm64e arm64
 CFLAGS+=-O2 -W -Wall -Wno-unused -Wno-unused-parameter -bundle -fPIC $(foreach ARCH,$(ARCHS),-arch $(ARCH))
 LDFLAGS=
 


### PR DESCRIPTION
Current mac version vimproc binary contain x86_64 and arm64e arches.
But in some mac environment, arm64 arch vim is used and arm64 version vim canot dlopen arm64e binary.
Actually my vim is arm64 so ↓ error is shown.

```
[vimproc] function quickrun#command#execute[10]..quickrun#run[10]..108[10]..100[1]..vimproc#pgroup_open[15]..<SNR>73_pgroup_open[7]..vimproc#plineopen3[6]..<SNR>73_plineopen[64]..<SNR>73_vp_pipe_open[10]..<SNR>73_libcall, line 1
[vimproc] Vim(let):dlerror = "dlopen(/Users/taisyo/.vim/plugged/vimproc/lib/vimproc_mac.so, 0x0005): tried: '/Users/taisyo/.vim/plugged/vimproc/lib/vimproc_mac.so' (fat file, but missing compatible architecture (have 'x86_64,arm64e', need 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/Users/taisyo/.vim/plugged/vimp
roc/lib/vimproc_mac.so' (no such file), '/Users/taisyo/.vim/plugged/vimproc/lib/vimproc_mac.so' (fat file, but missing compatible architecture (have 'x86_64,arm64e', need 'arm64'))"
[vimproc] Error occurred in calling s:vp_pipe_open()
[vimproc] a:argv = ['/usr/bin/env', 'bash', '/Users/taisyo/.pyenv/shims/python', '/Users/taisyo/(snip)']
[vimproc] original a:argv = ['/usr/bin/env', 'bash', '/Users/taisyo/.pyenv/shims/python', '/Users/taisyo/repository/(snip)']
Error detected while processing function quickrun#command#execute[13]..function quickrun#command#execute[10]..quickrun#run[10]..108[10]..100[1]..vimproc#pgroup_open[15]..<SNR>73_pgroup_open[7]..vimproc#plineopen3[6]..<SNR>73_plineopen[64]..<SNR>73_vp_pipe_open:
line   25:
E121: Undefined variable: fdlist
E116: Invalid arguments for function len(fdlist)
Press ENTER or type command to continue
```

therefore I added arm64 arch to fat-binary, It seems working well.